### PR TITLE
Added functionality to output alternative report formats via user-defined XSLT

### DIFF
--- a/src/main/ml-modules/root/test/default.xqy
+++ b/src/main/ml-modules/root/test/default.xqy
@@ -31,8 +31,8 @@ declare function local:run() {
 		if ($suite) then
 			let $result := helper:run-suite($suite, $tests, $run-suite-teardown, $run-teardown)
 			return
-				if ($format eq "junit") then
-					helper:format-junit($result)
+				if ($format) then
+					helper:format($result, $format, $suite)
 				else
 					$result
 		else ()

--- a/src/main/ml-modules/root/test/formats/j-unit.xsl
+++ b/src/main/ml-modules/root/test/formats/j-unit.xsl
@@ -1,0 +1,86 @@
+<!-- 
+    Convert default ml-uni-test report XML output to valid JUnit report XML
+-->
+<xsl:stylesheet version="2.0" 
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+    xmlns:t="http://marklogic.com/roxy/test" 
+    xmlns:error="http://marklogic.com/xdmp/error" 
+    exclude-result-prefixes="#all">
+    <xsl:output method="xml" encoding="utf-8" indent="yes"/>
+    
+    <!-- Required inputs -->
+    <xsl:param name="hostname"/>
+    <xsl:param name="timestamp"/>
+
+    <!-- Output all text nodes, elements and attributes -->   
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()" />
+        </xsl:copy>
+    </xsl:template>
+    
+    <!-- Output test suites -->
+    <xsl:template match="t:suite">
+        <testsuite errors="0" failures="{@failed}" hostname="{$hostname}" name="{@name}" tests="{@total}" time="{@time}" timestamp="{$timestamp}">
+            <xsl:apply-templates/>
+        </testsuite>
+    </xsl:template>
+    
+    <!-- Output test cases within test suites -->
+    <xsl:template match="t:test">
+        <testcase classname="{@name}" name="{@name}" time="{@time}">
+            <xsl:apply-templates/>
+        </testcase>
+    </xsl:template>
+    
+    <!-- Output test case failures -->
+    <xsl:template match="t:result[@type = 'fail']">
+        <failure type="{error:error/error:name/string()}" message="{error:error/error:message/string()}">
+            <xsl:apply-templates mode="serialize"/>
+        </failure>
+    </xsl:template>
+    
+    <!-- Prevent output test case successes -->
+    <xsl:template match="t:result[@type = 'success']"/>
+    
+    <!-- Serialize error stack output so document is valid JUnit XML -->
+    <xsl:template match="*" mode="serialize">
+        <xsl:text>&lt;</xsl:text>
+        <xsl:value-of select="name()"/>
+        <xsl:apply-templates select="@*" mode="serialize" />
+        <xsl:if test="name() = 'error:error'">
+            <xsl:for-each select="namespace::*">
+                <xsl:text> </xsl:text>
+                <xsl:value-of select="name()"/>
+                <xsl:text>="</xsl:text>
+                <xsl:value-of select="."/>
+                <xsl:text>"</xsl:text>
+            </xsl:for-each>
+        </xsl:if>
+        <xsl:choose>
+            <xsl:when test="node()">
+                <xsl:text>&gt;</xsl:text>
+                <xsl:apply-templates mode="serialize" />
+                <xsl:text>&lt;/</xsl:text>
+                <xsl:value-of select="name()"/>
+                <xsl:text>&gt;</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:text> /&gt;</xsl:text>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="@*" mode="serialize">
+        <xsl:text> </xsl:text>
+        <xsl:value-of select="name()"/>
+        <xsl:text>="</xsl:text>
+        <xsl:value-of select="."/>
+        <xsl:text>"</xsl:text>
+    </xsl:template>
+    
+    <xsl:template match="text()" mode="serialize">
+        <xsl:value-of select="."/>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/ml-modules/root/test/test-controller.xqy
+++ b/src/main/ml-modules/root/test/test-controller.xqy
@@ -13,8 +13,10 @@ import module namespace helper = "http://marklogic.com/roxy/test-helper" at "/te
 declare namespace t="http://marklogic.com/roxy/test";
 
 declare variable $FS-PATH as xs:string := if (xdmp:platform() eq "winnt") then "\" else "/";
-
 declare variable $TEST-SUITES-ROOT := "/test/suites/";
+declare variable $db-id as xs:unsignedLong := xdmp:modules-database();
+declare variable $root as xs:string := xdmp:modules-root();
+
 
 (:
  : Returns a list of the available tests. This list is magically computed based on the modules
@@ -28,13 +30,11 @@ declare function list()
 	)
 	return
 		element t:tests {
-			let $db-id as xs:unsignedLong := xdmp:modules-database()
-			let $root as xs:string := xdmp:modules-root()
 			let $suites as xs:string* :=
 				if ($db-id = 0) then
 					xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites"))/dir:entry[dir:type = "directory" and fn:not(dir:filename = $suite-ignore-list)]/dir:filename
 				else
-					let $uris := helper:list-from-database($db-id, $root, ())
+					let $uris := helper:list-from-database($db-id, $root, (), 'suites')
 					return
 						fn:distinct-values(
 							for $uri in $uris
@@ -42,32 +42,77 @@ declare function list()
 							where $path ne "" and fn:not(fn:contains($path, "/")) and fn:not($path = $suite-ignore-list)
 							return
 								$path)
-			for $suite as xs:string in $suites
-			let $tests as xs:string* :=
+			let $main-formats as xs:string* :=
 				if ($db-id = 0) then
-					xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites/", $suite))/dir:entry[dir:type = "file" and fn:not(dir:filename = $test-ignore-list)]/dir:filename[fn:ends-with(., ".xqy") or fn:ends-with(., ".sjs")]
+					xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/formats"))/dir:entry[dir:type = "file" and fn:not(dir:filename = $test-ignore-list)]/dir:filename[fn:ends-with(., ".xsl")]
 				else
-					let $uris := helper:list-from-database(
-						$db-id, $root, fn:concat($suite, '/'))
+					let $uris := helper:list-from-database($db-id, $root, (), 'formats')
 					return
 						fn:distinct-values(
 							for $uri in $uris
-							let $path := fn:replace($uri, fn:concat($root, "test/suites/", $suite, "/"), "")
-							where $path ne "" and fn:not(fn:contains($path, "/")) and fn:not($path = $test-ignore-list) and (fn:ends-with($path, ".xqy") or fn:ends-with($path, ".sjs"))
+							let $path := fn:replace($uri, fn:concat($root, "test/formats/"), "")
+							where $path ne "" and fn:not(fn:contains($path, "/")) and fn:not($path = $test-ignore-list) and (fn:ends-with($path, ".xsl"))
 							return
 								$path)
-			where $tests
-			return
-				element t:suite {
-					attribute path {$suite},
-					element t:tests {
-						for $test in $tests
-						return
-							element t:test {
-								attribute path {$test}
-							}
-					}
-				}
+			return (
+			    for $suite as xs:string in $suites
+			    let $tests as xs:string* :=
+				    if ($db-id = 0) then
+				        xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites/", $suite))/dir:entry[dir:type = "file" and fn:not(dir:filename = $test-ignore-list)]/dir:filename[fn:ends-with(., ".xqy") or fn:ends-with(., ".sjs")]
+				    else
+				        let $uris := helper:list-from-database(
+						    $db-id, $root, fn:concat($suite, '/'), 'suites')    
+					    return
+						    fn:distinct-values(
+						        for $uri in $uris
+						        let $path := fn:replace($uri, fn:concat($root, "test/suites/", $suite, "/"), "")
+						        where $path ne "" and fn:not(fn:contains($path, "/")) and fn:not($path = $test-ignore-list) and (fn:ends-with($path, ".xqy") or fn:ends-with($path, ".sjs"))
+						        return
+						            $path)
+			    let $formats as xs:string* :=
+			        if ($db-id = 0) then
+			            xdmp:filesystem-directory(fn:concat($root, $FS-PATH, "test/suites/", $suite, "/formats"))/dir:entry[dir:type = "file" and fn:not(dir:filename = $test-ignore-list)]/dir:filename[fn:ends-with(., ".xsl")]
+				    else
+					    let $uris := helper:list-from-database(
+						    $db-id, $root, fn:concat($suite, '/formats/'), 'suites')    
+					    return
+						    fn:distinct-values(
+							    for $uri in $uris
+							    let $path := fn:replace($uri, fn:concat($root, "test/suites/", $suite, "/formats/"), "")
+							    where $path ne "" and fn:not(fn:contains($path, "/")) and fn:not($path = $test-ignore-list) and (fn:ends-with($path, ".xsl"))
+							    return
+								    $path)
+			    where $tests
+			    return 
+				    element t:suite {
+					    attribute path {$suite},
+					    element t:tests {
+						    for $test in $tests
+						    return
+							    element t:test {
+								    attribute path {$test}
+							    }
+					    },
+					    if ($formats) then
+   					        element t:formats {
+                               for $format in $formats
+                               return
+                                   element t:format {
+                                       attribute path {$format}
+                                   }
+                           }
+                        else ()
+				    },
+				if ($main-formats) then
+				    element t:formats {
+				        for $main-format in $main-formats
+				        return
+				            element t:format {
+				                attribute path {$main-format}
+				            }
+				    }
+				else ()
+			)
 		}
 };
 
@@ -145,6 +190,29 @@ declare function run($suite as xs:string, $name as xs:string, $module, $run-tear
 			$teardown
 		}
 };
+
+
+declare function format($result as element(), $format as xs:string, $suite as xs:string)
+{
+    if ($format eq "junit") then
+        format-junit($suite)
+    else
+        let $format-uris := helper:list-from-database($db-id, $root, (), 'formats')
+        let $suite-format-uris := helper:list-from-database($db-id, $root, $suite || '/formats/', 'suites')
+        let $xsl-match := 
+            for $uri in ($format-uris, $suite-format-uris)
+            return 
+                if (fn:matches(fn:tokenize($uri, '/')[fn:last()], '^' || $format || '(\.xsl)?$')) then $uri
+                else ()
+        return 
+            if ($xsl-match) then
+                let $xsl := $xsl-match[1]
+                let $params := map:map()
+                let $_ := map:put($params, "hostname", fn:tokenize(xdmp:get-request-header("Host"), ":")[1])
+                let $_ := map:put($params, "timestamp", fn:current-dateTime())
+                return xdmp:xslt-invoke($xsl, $result, $params)/element()
+            else $result
+{;
 
 
 declare function format-junit($suite as element())

--- a/src/main/ml-modules/root/test/test-helper.xqy
+++ b/src/main/ml-modules/root/test/test-helper.xqy
@@ -556,7 +556,8 @@ declare function helper:log($items as item()*)
 declare function helper:list-from-database(
   $database as xs:unsignedLong,
   $root as xs:string,
-  $suite as xs:string?)
+  $suite as xs:string?,
+  $file-type as xs:string)
 as xs:string*
 {
   xdmp:eval(
@@ -567,7 +568,7 @@ as xs:string*
       if ($ex/error:code ne "XDMP-URILXCNNOTFOUND") then xdmp:rethrow()
       else xdmp:directory($PATH, "infinity")/xdmp:node-uri(.) }',
     (xs:QName('PATH'),
-      fn:concat($root, 'test/suites/', ($suite, '')[1])),
+      fn:concat($root, 'test/', $file-type, '/', ($suite, '')[1])),
     <options xmlns="xdmp:eval"><database>{$database}</database></options>)
 };
 

--- a/src/main/ml-modules/services/ml-unit-test.xqy
+++ b/src/main/ml-modules/services/ml-unit-test.xqy
@@ -38,8 +38,8 @@ declare private function run($params as map:map)
 		if ($suite) then
 			let $result := helper:run-suite($suite, $tests, $run-suite-teardown, $run-teardown)
 			return
-				if ($format eq "junit") then
-					helper:format-junit($result)
+				if ($format) then
+					helper:format($result, $format, $suite)
 				else
 					$result
 		else ()


### PR DESCRIPTION
Use of the existing `rs:format` parameter on the REST endpoint has been extended so that it is possible to define the name of an XSLT document that will be applied to the default ml-unit-test report XML to transform it into an alternative format. The inclusion of the `.xsl` extension in the parameter value is optional.

User-defined XSLT files can be placed either in the /test/formats directory or suite specific /test/suites/{suiteName}/formats directories. If XSLTs with the same name are in both directories then the latter takes precedence.

A pre-built j-unit.xsl transform is available in the /test/formats directory to output test results in the JUnit report format (although there is a pre-existing JUnit transform written in XQuery available within the code). This can be run using e.g. http://localhost:8135/v1/resources/ml-unit-test?rs:func=run&rs:suite=myTests&rs:format=j-unit

All available XSLTs have been included in the list of items returned by the `helper:list` function.