### PR TITLE
code coverage

### DIFF
--- a/src/main/ml-modules/root/test/css/coverage.css
+++ b/src/main/ml-modules/root/test/css/coverage.css
@@ -1,0 +1,91 @@
+/**
+* Copyright 2012-2018 MarkLogic Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* The use of the Apache License does not indicate that this project is
+* affiliated with the Apache Software Foundation.
+*
+* Code adapted from xray
+* https://github.com/robwhitby/xray/tree/v2.1
+*
+* Modifications copyright (c) 2018 MarkLogic Corporation
+**/
+
+ol.coverage-source li {
+    font-family: monospace;
+    margin-left: 30px;
+    color: #999;
+}
+ol.coverage-source li pre {
+    display: inline;
+    padding: 0 2px;
+    color: #000;
+}
+ol.coverage-source li.wanted pre { background-color: #f66; }
+ol.coverage-source li.covered pre { background-color: #6f6; }
+
+summary, ul li, ul pre { margin: 0; padding: 5px 10px; font-weight: normal; }
+summary {
+    display: block; /* for non webkit */
+    border-top-left-radius: 10px;
+    border-top-right-radius: 10px;
+    background-color: #ddd;
+    font-weight: bold;
+}
+
+section.coverage details {
+    margin-bottom: 2em;
+}
+section.coverage details > table {
+    border-top-left-radius: 0px;
+    border-top-right-radius: 0px;
+    border-bottom-left-radius: 10px;
+    border-bottom-right-radius: 10px;
+}
+section.coverage details > table thead th:first-child {
+    border-top-left-radius: 0px;
+}
+section.coverage details > table thead th:last-child {
+    border-top-right-radius: 0px;
+}
+section.coverage details > table tfoot th {
+    border-radius: 0px;
+}
+section.coverage details > table tfoot th:first-child  {
+    border-bottom-left-radius: 10px;
+}
+section.coverage details > table tfoot th:last-child {
+    border-bottom-right-radius: 10px;
+}
+
+.bar-chart {
+    width: 100%;
+    height: 1em;
+}
+span.bar {
+    display: inline-block;
+    height: 50%;
+    box-sizing: border-box;
+    float: left;
+    font-weight: bold;
+    font-family: arial, sans-serif;
+}
+
+.missed {
+    background: #f66;
+}
+
+.covered {
+    background: #6f6;
+}

--- a/src/main/ml-modules/root/test/default.xqy
+++ b/src/main/ml-modules/root/test/default.xqy
@@ -178,7 +178,7 @@ declare function local:main() {
 							<td><label for="runteardown">Run Teardown after each test</label><input id="runteardown" type="checkbox" checked="checked"/></td>
 						</tr>
 						<tr>
-							<td><label for="calculatecoverage">Calculate Coverage</label><input id="calculatecoverage" type="checkbox" checked="checked"/></td>
+							<td><label for="calculatecoverage">Calculate Coverage</label><input id="calculatecoverage" type="checkbox" /></td>
 						</tr>
 					</tbody>
 				</table>

--- a/src/main/ml-modules/root/test/test-coverage.xqy
+++ b/src/main/ml-modules/root/test/test-coverage.xqy
@@ -1,0 +1,436 @@
+xquery version "1.0-ml";
+(:
+ : Copyright 2012-2018 MarkLogic Corporation
+ :
+ : Licensed under the Apache License, Version 2.0 (the "License");
+ : you may not use this file except in compliance with the License.
+ : You may obtain a copy of the License at
+ :
+ :    http://www.apache.org/licenses/LICENSE-2.0
+ :
+ : Unless required by applicable law or agreed to in writing, software
+ : distributed under the License is distributed on an "AS IS" BASIS,
+ : WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ : See the License for the specific language governing permissions and
+ : limitations under the License.
+ :
+ :
+ : The use of the Apache License does not indicate that this project is
+ : affiliated with the Apache Software Foundation.
+ :
+ : Code adapted from xray
+ : https://github.com/robwhitby/xray/tree/v2.1
+ :
+ : Modifications copyright (c) 2018 MarkLogic Corporation
+ :)
+module namespace cover="http://marklogic.com/roxy/test-coverage";
+
+import module namespace helper = "http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+declare namespace t = "http://marklogic.com/roxy/test";
+declare default element namespace "http://marklogic.com/roxy/test";
+
+declare option xdmp:mapping "false";
+
+(: Half a million lines of XQuery ought to be enough for any module. :)
+declare variable $LIMIT as xs:integer := 654321 ;
+
+declare private function cover:_put(
+    $map as map:map,
+    $key as xs:string)
+{
+  map:put($map, $key, $key)
+};
+
+declare private function cover:_put-new(
+    $map as map:map,
+    $key as xs:string)
+{
+  if (fn:exists(map:get($map, $key))) then ()
+  else cover:_put($map, $key)
+};
+
+
+declare private function cover:_map-from-sequence(
+    $map as map:map,
+    $seq as xs:integer*)
+{
+  $seq ! cover:_put($map, xs:string(.)),
+  $map
+};
+
+declare private function cover:_map-from-sequence(
+    $seq as xs:integer*)
+{
+  cover:_map-from-sequence(map:map(), $seq)
+};
+
+declare private function cover:_task-cancel-safe(
+    $id as xs:unsignedLong)
+{
+  try {
+    (:TODO is this a good idea, or a bad idea??:)
+    for $breakpoint in dbg:breakpoints($id) return dbg:clear($id, $breakpoint),
+    xdmp:request-cancel(xdmp:host(), xdmp:server("TaskServer"), $id) }
+  catch ($ex) {
+    if ($ex/error:code eq 'XDMP-NOREQUEST') then ()
+    else xdmp:rethrow() }
+};
+
+declare private function cover:_prepare-from-request(
+    $request as xs:unsignedLong,
+    $uri as xs:string,
+    $limit as xs:integer,
+    $results-map as map:map)
+{
+  helper:log(text {'cover:_prepare-from-request', ('request', $request, 'module', $uri)}),
+  try {
+    let $lines-map := map:get($results-map, $uri)[2]
+    (: Semi-infinite loop, to be broken using DBG-LINE.
+     : This avoids stack overflow errors.
+     :)
+    for $line in 1 to $limit
+    (: We only need to break once per line, but we set a breakpoint
+     : on every expression to maximize the odds of seeing that line.
+     : But dbg:line will return the same expression more than once,
+     : at the start of a module or when it sees an expression
+     : that covers multiple lines. So we call dbg:expr for the right info.
+     : Faster to loop once and call dbg:expr many extra times,
+     : or gather all unique expr-ids and then loop again?
+     : Because of the loop-break technique, one loop is easier.
+     :)
+    for $expr-id in dbg:line($request, $uri, $line)
+    let $set := dbg:break($request, $expr-id)
+    let $expr := dbg:expr($request, $expr-id)
+    let $key := $expr/dbg:line/fn:string()
+    where fn:not(map:get($lines-map, $key))
+    return cover:_put($lines-map, $key),
+
+    (: We should always hit EOF and DBG-LINE before this.
+     : Tell the caller that we could not do it.
+     :)
+    cover:_task-cancel-safe($request),
+    fn:error((), 'UNIT-TEST-TOOBIG', ('Module is too large for code coverage limit:', $limit))
+  } catch ($ex) {
+    if ($ex/error:code = "DBG-LINE") then ()
+    else if ($ex/error:code = ("DBG-MODULEDNE", "DBG-REQUESTRECORD", "XDMP-MODNOTFOUND")) then
+      helper:log("Error executing " || $uri || " " || ($ex/*:code))
+    else
+      (
+        (: Avoid leaving tasks in error state on the task server. :)
+        cover:_task-cancel-safe($request),
+        xdmp:rethrow()
+      )
+  }
+};
+
+(:~
+ : This function prepares code coverage information for the specified modules.
+ :)
+declare private function cover:_prepare(
+    $coverage-modules as xs:string+,
+    $results-map as map:map,
+    $test-module as xs:string)
+  as map:map
+{
+  (: When this comes back, each map key will have two entries:
+   : covered-lines-map, wanted-lines-map.
+   : The wanted-lines-map will be an identity map.
+   :)
+  for $module in $coverage-modules
+  where fn:empty(map:get($results-map, $module))
+  return map:put($results-map, $module, (map:map(), map:map()))
+  ,
+  (: we can't currently debug SJS modules, so in order to avoid exceptions, just skip :)
+  if (fn:ends-with($test-module, ".sjs")) then $results-map
+  else
+    let $request := dbg:invoke($test-module)
+    let $do := (
+        helper:log("debugging test module: " || $test-module || " for request " || $request),
+        $coverage-modules ! _prepare-from-request($request, ., $LIMIT, $results-map),
+        _task-cancel-safe($request),
+        helper:log("cancelled " || $request)
+      )
+    return
+      $results-map
+};
+
+(:~
+ : This function prepares code coverage information for the specified modules.
+ :)
+declare function cover:prepare(
+    $coverage-modules as xs:string*,
+    $test-modules as xs:string*)
+  as map:map?
+{
+  if (fn:empty($coverage-modules)) then ()
+  else
+    let $results-map := map:map()
+    let $_ :=
+      for $test-module in $test-modules
+      return cover:_prepare($coverage-modules, $results-map, $test-module)
+    return
+      $results-map
+};
+
+declare private function cover:_result(
+    $name as xs:string,
+    $map as map:map)
+{
+  element { $name } {
+    attribute count { map:count($map) },
+    for $line in map:keys($map)
+    let $line-number := xs:integer($line)
+    order by $line-number
+    return $line-number
+  }
+};
+
+declare function cover:results(
+    $results-map as map:map,
+    $results as item()*)
+{
+  $results[fn:not(. instance of element(prof:report))]
+  ,
+  (: report test-level coverage data :)
+  let $modules := map:keys($results-map)
+  let $do :=
+    (: Populate the coverage maps from the profiler output. :)
+    for $expr in $results[. instance of element(prof:report)]/prof:histogram/prof:expression[prof:uri = $modules]
+    let $module := map:get($results-map, $expr/prof:uri)[1]
+    let $key := $expr/prof:line/fn:string()
+    where fn:not(map:get($module, $key))
+    return cover:_put($module, $key)
+
+  for $uri in $modules
+  let $seq := map:get($results-map, $uri)
+  let $covered := $seq[1]
+  let $wanted := $seq[2]
+  let $assert := (
+    if (map:count($covered - $wanted) eq 0) then ()
+    else
+      helper:log(
+        fn:string-join(
+            ('cover:results',
+            ($uri, "more coverage than expected: lines = ",
+            map:keys($covered - $wanted)), 'warning'), " ")) )
+  order by $uri
+  return
+    element t:coverage {
+      attribute uri { $uri },
+      cover:_result('wanted', $wanted),
+      cover:_result('covered', $covered),
+      cover:_result('missing', $wanted - $covered)
+    }
+};
+
+(:~
+ : Return a list of the XQuery modules eligible for code coverage.
+:)
+declare function list-coverage-modules() as xs:string* {
+  let $database-id as xs:unsignedLong := xdmp:modules-database()
+  let $modules-root as xs:string := xdmp:modules-root()
+  let $module-extensions as xs:string* := (".xqy", ".xqe", ".xq", ".xquery")
+  return
+    if ($database-id = 0) then
+      list-coverage-modules-from-filesystem($modules-root, $module-extensions)
+    else
+      list-coverage-modules-from-database($database-id, $modules-root, $module-extensions)
+};
+
+declare function list-coverage-modules-from-database(
+    $database-id as xs:unsignedLong,
+    $modules-root as xs:string,
+    $module-extensions as xs:string+)
+{
+  xdmp:invoke-function(
+    function() {
+      try {
+        for $extension in $module-extensions
+        return cts:uri-match("*" || $extension, ("document", "case-insensitive", "diacritic-sensitive"))
+      }
+      catch ($ex) {
+        if ($ex/error:code ne "XDMP-URILXCNNOTFOUND") then xdmp:rethrow()
+        else
+          for $uri in xdmp:directory($modules-root, "infinity")/xdmp:node-uri(.)
+          let $lower-case-uri := lower-case($uri)
+          where some $extension in $module-extensions satisfies ends-with($lower-case-uri, $extension)
+          return $uri
+      }
+    },
+    <options xmlns="xdmp:eval">
+      <database>{$database-id}</database>
+    </options>
+  )
+};
+
+(:~
+ : List the modules in the specified filesystem directory, and it's subdirectories
+ :)
+declare function list-coverage-modules-from-filesystem(
+    $modules-root as xs:string,
+    $module-extensions as xs:string+)
+{
+  for $entry in xdmp:filesystem-directory($modules-root)/dir:entry
+  where fn:not($entry/dir:filename = (".svn", "CVS", ".DS_Store"))
+  return
+    if ($entry[dir:type eq "file"]) then
+      for $path in $entry/dir:pathname/string()
+      let $lower-case-path := lower-case($path)
+      where some $extension in $module-extensions satisfies ends-with($lower-case-path, $extension)
+      return $path
+    else
+      list-coverage-modules-from-filesystem($entry/dir:pathname/string(), $module-extensions)
+};
+
+(:~
+ : Generate the coverage summary for all the Suite coverage data,
+ : and add it to the response.
+ :)
+declare function cover:summary(
+    $tests as element()
+  ) as element()
+{
+  element { fn:node-name($tests) } {
+    $tests/(@*|node()),
+
+    let $map := map:map()
+    let $do :=
+      for $coverage in $tests/t:suite/t:test/t:coverage
+      let $uri := $coverage/@uri/fn:string()
+      let $old := map:get($map, $uri)
+      let $coverage-tuple := (
+        (: Do we already have a 'wanted' list for this uri? :)
+        if (fn:exists($old)) then $old
+        else
+          (: if not, lets create a new one :)
+          let $new := (map:map(), map:map())
+          let $put := map:put($map, $uri, $new)
+          return $new
+      )
+      let $covered := $coverage-tuple[1]
+      let $wanted := $coverage-tuple[2]
+      return (
+        for $line in xs:NMTOKENS($coverage/covered)
+        return cover:_put-new($covered, $line),
+
+        for $line in xs:NMTOKENS($coverage/wanted)
+        return cover:_put-new($wanted, $line)
+      )
+
+    let $uris := map:keys($map)
+    let $covered-count := fn:sum( for $uri in $uris return map:count(map:get($map, $uri)[1]) )
+    let $wanted-count := fn:sum( for $uri in $uris return map:count(map:get($map, $uri)[2]) )
+    return
+      element t:coverage-summary {
+        attribute wanted-count { $wanted-count },
+        attribute covered-count { $covered-count },
+        attribute missing-count { $wanted-count - $covered-count },
+        (: by module :)
+        for $uri in $uris
+        let $coverage-tuple := map:get($map, $uri)
+        let $covered := $coverage-tuple[1]
+        let $wanted := $coverage-tuple[2]
+        order by $uri
+        return
+          element t:module-coverage {
+            attribute uri { $uri },
+            cover:_result('wanted', $wanted),
+            cover:_result('covered', $covered),
+            cover:_result('missing', $wanted - $covered)
+          }
+      }
+  }
+};
+
+declare function cover:module-view-text(
+    $module as xs:string,
+    $lines as xs:string*,
+    $wanted as map:map,
+    $covered as map:map,
+    $missing as map:map)
+{
+  text { 'Module', $module },
+  for $i at $x in $lines
+  let $key := fn:string($x)
+  return text {
+    if (map:get($covered, $key)) then '+'
+    else if (map:get($wanted, $key)) then '!'
+    else ' ',
+    $x, $i
+  }
+};
+
+declare function cover:module-view-xml(
+    $module as xs:string,
+    $lines as xs:string*,
+    $wanted as map:map,
+    $covered as map:map,
+    $missing as map:map)
+{
+  element t:module {
+    attribute uri { $module },
+    attribute covered { map:count($covered) },
+    attribute wanted { map:count($wanted) },
+
+    for $i at $x in $lines
+    let $key := fn:string($x)
+    return
+      element t:line {
+        attribute number { $x },
+        attribute state {
+          if (map:get($covered, $key)) then 'covered'
+          else if (map:get($wanted, $key)) then 'wanted'
+          else 'none'
+        },
+        $i
+      }
+  }
+};
+
+declare function cover:module-view(
+    $module as xs:string,
+    $format as xs:string,
+    $lines as xs:string*,
+    $wanted as map:map,
+    $covered as map:map,
+    $missing as map:map)
+{
+  if ($format eq "html") then
+    xdmp:xslt-invoke(
+        fn:concat("/test/xslt/coverage/module/", $format, ".xsl"),
+        cover:module-view-xml($module, $lines, $wanted, $covered, $missing)
+    )
+  else if ($format eq "text") then cover:module-view-text($module, $lines, $wanted, $covered, $missing)
+  else if ($format eq "xml") then cover:module-view-xml($module, $lines, $wanted, $covered, $missing)
+  else fn:error((), "UNIT-TEST-BADFORMAT", ("Format invalid for code coverage view: ", $format))
+};
+
+
+declare function cover:module-view(
+    $module as xs:string,
+    $format as xs:string,
+    $lines as xs:string*,
+    $wanted as map:map,
+    $covered as map:map
+)
+{
+  cover:module-view($module, $format, $lines, $wanted, $covered, $wanted - $covered)
+};
+
+
+declare function cover:module-view(
+    $module as xs:string,
+    $format as xs:string,
+    $wanted as xs:integer*,
+    $covered as xs:integer*
+)
+{
+  let $source :=
+    try {
+      fn:tokenize(helper:get-modules-file($module), '\n')
+    } catch ($ex) {
+      $ex/error:format-string
+    }
+  return
+    cover:module-view($module, $format, $source, cover:_map-from-sequence($wanted), cover:_map-from-sequence($covered))
+};

--- a/src/main/ml-modules/root/test/xslt/coverage/common.xsl
+++ b/src/main/ml-modules/root/test/xslt/coverage/common.xsl
@@ -1,0 +1,46 @@
+<!--
+ Copyright 2012-2018 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ The use of the Apache License does not indicate that this project is
+ affiliated with the Apache Software Foundation.
+
+ Code adapted from xray
+ https://github.com/robwhitby/xray/tree/v2.1
+
+ Modifications copyright (c) 2018 MarkLogic Corporation
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:test="http://marklogic.com/roxy/test"
+                xmlns:xdmp="http://marklogic.com/xdmp"
+                xmlns:error="http://marklogic.com/xdmp/error"
+                xmlns:prof="http://marklogic.com/xdmp/profile"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                version="2.0"
+                exclude-result-prefixes="error prof test xdmp xs">
+
+  <xsl:template name="html-head">
+    <head>
+      <title>ml-unit-test</title>
+      <link rel="stylesheet" type="text/css" href="css/coverage.css" />
+    </head>
+  </xsl:template>
+
+  <xsl:function name="test:coverage-percent" as="xs:int">
+    <xsl:param name="covered" as="xs:int"/>
+    <xsl:param name="wanted" as="xs:int"/>
+    <xsl:value-of select="if ($wanted ne 0) then min((100, round(100 * $covered div $wanted))) else 0"/>
+  </xsl:function>
+
+</xsl:stylesheet>

--- a/src/main/ml-modules/root/test/xslt/coverage/module/html.xsl
+++ b/src/main/ml-modules/root/test/xslt/coverage/module/html.xsl
@@ -1,0 +1,65 @@
+<!--
+ Copyright 2012-2018 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ The use of the Apache License does not indicate that this project is
+ affiliated with the Apache Software Foundation.
+
+ Code adapted from xray
+ https://github.com/robwhitby/xray/tree/v2.1
+
+ Modifications copyright (c) 2018 MarkLogic Corporation
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:error="http://marklogic.com/xdmp/error"
+                xmlns:prof="http://marklogic.com/xdmp/profile"
+                xmlns:test="http://marklogic.com/roxy/test"
+                xmlns:xdmp="http://marklogic.com/xdmp"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                version="2.0"
+                exclude-result-prefixes="error prof test xdmp xs">
+
+  <xsl:output method="html" doctype-system="about:legacy-compat" encoding="UTF-8" indent="yes" />
+
+  <xsl:include href="../common.xsl"/>
+
+  <xsl:template match="test:module | test:suite">
+    <html>
+      <xsl:call-template name="html-head"/>
+      <body>
+        <section>
+          <details open="true">
+            <summary>
+              <xsl:value-of select="concat('Code Coverage for ',
+                                            @uri,
+                                            ':',
+                                            test:coverage-percent(xs:int(@covered), xs:int(@wanted)),
+                                            '%')"/>
+            </summary>
+            <ol class="coverage-source">
+              <xsl:apply-templates/>
+            </ol>
+          </details>
+        </section>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="test:line">
+   <li class="{@state}">
+     <pre><xsl:value-of select="."/></pre>
+   </li>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/ml-modules/root/test/xslt/coverage/report/html.xsl
+++ b/src/main/ml-modules/root/test/xslt/coverage/report/html.xsl
@@ -1,0 +1,120 @@
+<!--
+ Copyright 2012-2018 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ The use of the Apache License does not indicate that this project is
+ affiliated with the Apache Software Foundation.
+
+ Code adapted from xray
+ https://github.com/robwhitby/xray/tree/v2.1
+
+ Modifications copyright (c) 2018 MarkLogic Corporation
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:error="http://marklogic.com/xdmp/error"
+                xmlns:prof="http://marklogic.com/xdmp/profile"
+                xmlns:test="http://marklogic.com/roxy/test"
+                xmlns:xdmp="http://marklogic.com/xdmp"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                version="2.0"
+                exclude-result-prefixes="error prof test xdmp xs">
+
+  <xsl:output method="html" doctype-system="about:legacy-compat" encoding="UTF-8" indent="yes" />
+
+  <xsl:include href="../common.xsl"/>
+
+  <xsl:template match="test:tests">
+    <html>
+      <xsl:call-template name="html-head"/>
+      <body>
+        <xsl:apply-templates select="test:coverage-summary"/>
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="test:coverage-summary">
+    <xsl:variable name="total-coverage" select="test:coverage-percent(xs:int(@covered-count), xs:int(@wanted-count))"/>
+    <section class="coverage">
+      <details open="true">
+        <summary>
+          <xsl:text>Code Coverage: </xsl:text>
+          <xsl:value-of select="$total-coverage"/>
+          <xsl:text>%</xsl:text>
+        </summary>
+        <table cellspacing="0" cellpadding="0">
+          <thead>
+            <tr>
+              <th>Module</th>
+              <th>Missed Lines</th>
+              <th>Coverage</th>
+              <th>Missed</th>
+              <th>Covered</th>
+              <th>Lines</th>
+            </tr>
+          </thead>
+          <tbody>
+            <xsl:apply-templates>
+              <xsl:sort select="test:missing/@count" data-type="number" order="descending"/>
+              <xsl:sort select="test:covered/@count" data-type="number" order="descending"/>
+              <xsl:sort select="test:wanted/@count" data-type="number" order="descending"/>
+            </xsl:apply-templates>
+          </tbody>
+          <tfoot>
+            <tr>
+              <th>Total</th>
+              <th><xsl:value-of select="concat(@missing-count, ' of ', @wanted-count)"/></th>
+              <th><span class="pct"><xsl:value-of select="$total-coverage"/>%</span></th>
+              <th><xsl:value-of select="@missing-count"/></th>
+              <th><xsl:value-of select="@covered-count"/></th>
+              <th><xsl:value-of select="@wanted-count"/></th>
+            </tr>
+          </tfoot>
+        </table>
+      </details>
+    </section>
+  </xsl:template>
+
+  <xsl:template match="test:module-coverage">
+    <xsl:variable name="link"
+                  select="concat('default.xqy?func=coverage-module',
+                                   '&amp;format=html',
+                                   '&amp;module=', encode-for-uri(@uri),
+                                   '&amp;wanted=', encode-for-uri(test:wanted/string()),
+                                   '&amp;covered=', encode-for-uri(test:covered/string()))"/>
+    <xsl:variable name="pct" select="test:coverage-percent(xs:int(test:covered/@count), xs:int(test:wanted/@count))"/>
+    <xsl:variable name="status">
+      <xsl:choose>
+        <xsl:when test="$pct eq 100">passed</xsl:when>
+        <xsl:when test="$pct le 0">ignored</xsl:when>
+        <xsl:otherwise>failed</xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <tr class="{$status} {if (position() mod 2) then () else 'even'}">
+      <td><a href="{$link}" target="_blank"><xsl:value-of select="@uri"/></a></td>
+      <td>
+        <div style="width:{ max(( 2, round(100 * ( max((test:wanted/@count, 1)) div max(../*/test:wanted/@count) ) ) ))}%">
+        <div class="bar-chart">
+          <span style="width:{100 - $pct}%" class="bar missed" title="{test:missing/@count}" alt="{test:missing/@count}"/>
+          <span style="width:{$pct}%" class="bar covered" title="{test:covered/@count}" alt="{test:covered/@count}"/>
+        </div>
+        </div>
+      </td>
+      <td><span class="pct"><xsl:value-of select="$pct"/>%</span></td>
+      <td><xsl:value-of select="test:missing/@count"/></td>
+      <td><xsl:value-of select="test:covered/@count"/></td>
+      <td><xsl:value-of select="test:wanted/@count"/></td>
+    </tr>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/ml-modules/root/test/xslt/coverage/report/xml.xsl
+++ b/src/main/ml-modules/root/test/xslt/coverage/report/xml.xsl
@@ -1,0 +1,40 @@
+<!--
+ Copyright 2012-2018 MarkLogic Corporation
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ The use of the Apache License does not indicate that this project is
+ affiliated with the Apache Software Foundation.
+
+ Code adapted from xray
+ https://github.com/robwhitby/xray/tree/v2.1
+
+ Modifications copyright (c) 2018 MarkLogic Corporation
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:test="http://marklogic.com/roxy/test"
+                xmlns:error="http://marklogic.com/xdmp/error"
+                xmlns:prof="http://marklogic.com/xdmp/profile"
+                version="2.0">
+
+  <xsl:output method="xml" omit-xml-declaration="yes"/>
+
+  <xsl:template match="prof:report"/>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Code coverage for XQuery modules. 

The executable lines are obtained by using the `dbg:` debug API to set breakpoints and capture the executable lines for all of the XQuery modules (SJS not currently supported), and then capture the actual lines executed by capturing the output of the `prof:` profiler execution.

This is a port of the implementation on the [xray v2.1 feature branch](https://github.com/robwhitby/xray/tree/v2.1). XRay has an [Apache 2.0 license](https://github.com/robwhitby/xray/blob/v2.1/LICENCE), so there should be no problems incorporating the adapted code.

The UI has been adjusted to allow users to execute code coverage and display the coverage below the test results. Results display the coverage information for each module with numbers of Wanted, Covered, Missed, % and a bar chart of missed/covered lines. Each module is hyperlinked and will open a new page displaying the covered lines with a green background, missed lines with a red background. Default behavior is to not enable coverage for every test run. Users must select the Code Coverage checkbox in the options.

Code coverage could be calculated and for all suites and generate an XML response with coverage and test execution results by executing the `test:run-tests()` convenience method defined in the test-controller.xqy:

    import module namespace test = "http://marklogic.com/roxy/test-helper" 
        at "/test/test-controller.xqy";
    test:run-tests()