### PR TITLE
run setup/teardown with coverage and ensure all executed lines included in wanted lines

### DIFF
--- a/ml-unit-test-modules/src/main/ml-modules/root/test/test-controller.xqy
+++ b/ml-unit-test-modules/src/main/ml-modules/root/test/test-controller.xqy
@@ -142,10 +142,15 @@ declare function run-suite(
 		else list()/t:suite[@path eq $suite]/t:tests/t:test/@path
 	let $coverage :=
 		if ($calculate-coverage) then
-		(: TODO: should we exclude the test modules from what is covered?
-					i.e. cover:list-coverage-modules()[fn:not(fn:starts-with(., $TEST-SUITES-ROOT))]
-			:)
-			cover:prepare(cover:list-coverage-modules(), $tests ! fn:concat($TEST-SUITES-ROOT, $suite, "/", .))
+			(
+				run-setup-teardown(fn:true(), $suite),
+				let $coverage-modules := cover:list-coverage-modules()[fn:not(fn:starts-with(., $TEST-SUITES-ROOT))]
+				let $test-modules :=	$tests ! fn:concat($TEST-SUITES-ROOT, $suite, "/", .)
+			  return cover:prepare($coverage-modules, $test-modules),
+				if ($run-suite-teardown eq fn:true()) then
+					run-setup-teardown(fn:false(), $suite)
+				else ()
+			)
 		else ()
 	let $results :=
 		element t:run {


### PR DESCRIPTION
- Run setup/teardown with coverage calculation
  - Stepping through modules with dbg:* methods can alter state, and cause tests that would otherwise pass to fail when calculating code coverage. Execute setup and teardown, in order to ensure that suite is in a clean state before executing tests.
- add covered lines not found from stepping through dbg:*
  - I have observed more **_covered_** lines than **_wanted_** lines calculated from stepping through dbg:* methods. If there are additional lines executed than originally calculated, add them to the wanted list. It ensures that the math and presentation of coverage data is consistent.