### PR TITLE
Issue 28

### DIFF
--- a/ml-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-json.sjs
+++ b/ml-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-json.sjs
@@ -1,0 +1,92 @@
+
+// Given two JSON objects or arrays, determine whether they are the same.
+
+const test = require("/test/test-helper.xqy");
+
+let j0 = 
+  {
+    "PersonNameType":{
+      "PersonSurName":"SMITH",
+      "PersonGivenName":"LINDSEY"
+    }
+  };
+
+let j1 = 
+  {
+    "PersonNameType":{
+      "PersonSurName":"JONES",
+      "PersonGivenName":"LINDSEY"
+    },
+    "charges": [1,true,"a",null] 
+  };
+
+let j2 =
+  {
+    "PersonNameType":{
+      "PersonSurName":"JONES",
+      "PersonGivenName":"LINDSEY"
+    },
+    "charges": [1,true,"a",null]
+  };
+
+let j3 =
+  {
+    "PersonNameType":{
+      "PersonGivenName":"LINDSEY", 
+      "PersonSurName":"JONES"
+    },
+    "charges": [1,true,"a",null]
+  };
+
+let j4 =
+  {
+    "PersonNameType":{
+      "PersonGivenName": "LINDSEY",
+      "PersonSurName": "JONES"
+    },
+    "charges": [1, true, "a", null]
+  };
+
+let j5 =
+  {
+    "PersonNameType":{
+      "PersonGivenName": "LINDSEY",
+      "PersonSurName": "JONES"
+    },
+    "charges": [1, true, "a", null]
+  };
+
+/**
+ * test.assertEqualJson expects an xdmp:function, but a JS function is not one of those. 
+ * @param f 
+ * @param msg 
+ */
+function assertThrowsError(f, msg)
+{
+  try {
+    f();
+    test.fail(msg);
+  }
+  catch (e) {
+    test.success();
+  }
+}
+
+[
+  test.assertEqualJson(j1, j2),
+  test.assertEqualJson(j1, j3),
+  test.assertEqualJson(j2, j3),
+  test.assertEqualJson(j4, j5),
+  test.assertEqualJson(j2, j4),
+  test.assertEqualJson(j2, j5),
+
+  test.assertEqualJson(1, 1),
+  test.assertEqualJson('a', 'a'),
+
+  assertThrowsError(
+    function() {
+      test.assertEqualJson(j0, j5)
+    }, 
+    "ASSERT-EQUAL-JSON-FAILED"
+  )
+]

--- a/ml-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-json.xqy
+++ b/ml-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assert-equal-json.xqy
@@ -4,19 +4,19 @@ declare option xdmp:mapping "false";
 
 let $j0 := xdmp:to-json(xdmp:from-json-string(
   '{"PersonNameType":{"PersonSurName":"SMITH","PersonGivenName":"LINDSEY"}}'
-))
+))/node()
 
 let $j1 := xdmp:to-json(xdmp:from-json-string(
   '{"PersonNameType":{"PersonSurName":"JONES","PersonGivenName":"LINDSEY"},"charges":[1,true,"a",null]}'
-))
+))/node()
 
 let $j2 := xdmp:to-json(xdmp:from-json-string(
   '{"PersonNameType":{"PersonSurName":"JONES","PersonGivenName":"LINDSEY"},"charges":[1,true,"a",null]}'
-))
+))/node()
 
 let $j3 := xdmp:to-json(xdmp:from-json-string(
   '{"PersonNameType":{"PersonGivenName":"LINDSEY", "PersonSurName":"JONES"},"charges":[1,true,"a",null]}'
-))
+))/node()
 
 let $j4 :=
   let $o := json:object()
@@ -51,8 +51,12 @@ return xdmp:eager((
   test:assert-equal-json($j1, $j3),
   test:assert-equal-json($j2, $j3),
   test:assert-equal-json($j4, $j5),
-  test:assert-equal-json($j2, $j4),
-  test:assert-equal-json($j2, $j5),
+  test:assert-throws-error(function() {
+    test:assert-equal-json($j2, $j4)
+  }, "ASSERT-EQUAL-JSON-FAILED"),
+  test:assert-throws-error(function() {
+    test:assert-equal-json($j2, $j5)
+  }, "ASSERT-EQUAL-JSON-FAILED"),
   test:assert-throws-error(function() {
     test:assert-equal-json($j0, $j5)
   }, "ASSERT-EQUAL-JSON-FAILED")

--- a/ml-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assertEqual.sjs
+++ b/ml-unit-test-client/src/test/ml-modules/root/test/suites/Unit Test Tests/assertEqual.sjs
@@ -1,0 +1,4 @@
+
+const helper = require('/test/test-helper.xqy');
+
+helper.assertEqual([1, 'b'],[1, 'b']);

--- a/ml-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/ml-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -218,9 +218,13 @@ declare function helper:assert-at-least-one-equal($expected as item()*, $actual 
 
 declare private function helper:are-these-equal($expected as item()*, $actual as item()*) {
   if (fn:count($expected) eq fn:count($actual)) then
-    fn:count((for $item at $i in $expected
-    return
-      fn:deep-equal($item, $actual[$i]))[. = fn:true()]) eq fn:count($expected)
+    if ($expected instance of json:array and $actual instance of json:array) then
+      helper:assert-equal-json-recursive($expected, $actual)
+    else
+      fn:count((
+        for $item at $i in $expected
+        return
+          fn:deep-equal($item, $actual[$i]))[. = fn:true()]) eq fn:count($expected)
   else
     fn:false()
 };
@@ -303,12 +307,50 @@ declare function helper:assert-equal-xml($expected, $actual) {
       helper:assert-true(fn:false(), ("unsupported type in $actual : ", xdmp:path($actual)))
 };
 
-declare function helper:assert-equal-json($expected as map:map, $actual as map:map) {
-  let $equal := helper:assert-equal-json-recursive($expected, $actual)
-  return
-    if ($equal) then helper:success()
+declare function helper:assert-equal-json($expected, $actual) {
+  if ($expected instance of object-node()*) then
+    if ($actual instance of object-node()*) then
+      if (fn:count($expected) = fn:count($actual)) then
+        if (helper:assert-equal-json-recursive($expected, $actual)) then 
+          helper:success()
+        else
+          fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed", ($expected, $actual))
+      else
+        fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed (different counts of objects)", ($expected, $actual))
     else
-      fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed", ($expected, $actual))
+      (: $actual is not object-node()* :)
+      fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed ($actual does not consist of objects)", ($expected, $actual))
+  else if ($expected instance of map:map*) then
+    if ($actual instance of map:map*) then 
+      if (fn:count($expected) = fn:count($actual)) then
+        if (helper:assert-equal-json-recursive($expected, $actual)) then 
+          helper:success()
+        else
+          fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed", ($expected, $actual))
+      else
+        fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed (different counts of objects)", ($expected, $actual))
+    else
+      fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed ($actual does not consist of objects)", ($expected, $actual))
+  else if ($expected instance of array-node()*) then
+    if ($actual instance of array-node()*) then 
+      if (fn:count($expected) = fn:count($actual)) then
+        if (helper:assert-equal-json-recursive($expected, $actual)) then 
+          helper:success()
+        else
+          fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed", ($expected, $actual))
+      else
+        fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed (different counts of arrays)", ($expected, $actual))
+    else
+      fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed ($actual does not consist of arrays)", ($expected, $actual))
+  else if ($expected instance of document-node()) then
+    if ($actual instance of document-node()) then 
+      (: TODO - compare documents :)
+      ()
+    else
+      fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed ($actual is not a document)", ($expected, $actual))
+  else
+    (: scalar values :)
+    helper:assert-equal($expected, $actual)
 };
 
 declare function helper:assert-equal-json-recursive($object1, $object2) as xs:boolean
@@ -335,6 +377,19 @@ declare function helper:assert-equal-json-recursive($object1, $object2) as xs:bo
           helper:assert-equal-json-recursive($item, $o2[$i])
       return
         $counts-equal and fn:not($items-equal = fn:false())
+    case object-node() return
+      let $m1 := fn:data($object1)
+      let $m2 := fn:data($object2)
+      let $k1 := map:keys($m1)
+      let $k2 := map:keys($m2)
+      let $counts-equal := fn:count($k1) eq fn:count($k2)
+      let $maps-equal :=
+        for $key in map:keys($m1)
+        let $v1 := map:get($m1, $key)
+        let $v2 := map:get($m2, $key)
+        return
+          helper:assert-equal-json-recursive($v1, $v2)
+      return $counts-equal and fn:not($maps-equal = fn:false())
     default return
       $object1 = $object2
 };

--- a/ml-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
+++ b/ml-unit-test-modules/src/main/ml-modules/root/test/test-helper.xqy
@@ -344,8 +344,13 @@ declare function helper:assert-equal-json($expected, $actual) {
       fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed ($actual does not consist of arrays)", ($expected, $actual))
   else if ($expected instance of document-node()) then
     if ($actual instance of document-node()) then 
-      (: TODO - compare documents :)
-      ()
+      if (fn:count($expected) = fn:count($actual)) then
+        if (helper:assert-equal-json-recursive($expected/node(), $actual/node())) then 
+          helper:success()
+        else
+          fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed (documents not equal)", ($expected, $actual))
+      else
+        fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed (different counts of documents)", ($expected, $actual))
     else
       fn:error(xs:QName("ASSERT-EQUAL-JSON-FAILED"), "Assert Equal Json failed ($actual is not a document)", ($expected, $actual))
   else


### PR DESCRIPTION
- expanded JSON comparisons
- change: json:array and array-node no longer considered the same