### PR TITLE
Expand support for http helpers for REST tests

### DIFF
--- a/ml-unit-test-client/build.gradle
+++ b/ml-unit-test-client/build.gradle
@@ -64,4 +64,49 @@ if (project.hasProperty("myBintrayUser")) {
 	}
 }
 
+task createHttpCredentials(type: com.marklogic.gradle.task.MarkLogicTask) {
+  def client = getAppConfig().newAppServicesDatabaseClient("Security")
+  String xquery = """
+xquery version "1.0-ml";
+
+import module namespace sec = "http://marklogic.com/xdmp/security"
+      at "/MarkLogic/security.xqy";
+
+declare option xdmp:mapping "false";
+
+try {
+  sec:remove-credential("ml-unit-test-credentials")
+} catch (\$e) {()};
+
+xquery version "1.0-ml";
+
+import module namespace sec = "http://marklogic.com/xdmp/security"
+      at "/MarkLogic/security.xqy";
+
+declare option xdmp:mapping "false";
+
+sec:create-credential(
+   "ml-unit-test-credentials",
+   "Credentials for ML Rest Helper Calls",
+   "${mlUsername}",
+   "${mlPassword}",
+   (),
+   (),
+   fn:false(),
+   sec:uri-credential-target("http://localhost:${mlRestPort}/.*","digest"),
+   xdmp:default-permissions()
+)
+""";
+  try {
+    String result
+    result = client.newServerEval().xquery(xquery).evalAs(String.class);
+    if (result != null) {
+      println result
+    }
+  } finally {
+    client.release()
+  }
+}
+
+mlPostDeploy.dependsOn createHttpCredentials
 tasks.test.dependsOn mlDeploy

--- a/ml-unit-test-client/src/test/ml-modules/root/test/suites/More Unit Tests/http-helpers.xqy
+++ b/ml-unit-test-client/src/test/ml-modules/root/test/suites/More Unit Tests/http-helpers.xqy
@@ -1,0 +1,5 @@
+import module namespace test="http://marklogic.com/roxy/test-helper" at "/test/test-helper.xqy";
+
+
+test:assert-http-get-status("v1/search?format=xml", $test:DEFAULT_HTTP_OPTIONS,200),
+test:assert-http-post-status("v1/search?format=xml", $test:DEFAULT_HTTP_OPTIONS, (), 200)


### PR DESCRIPTION
add convenience functions (and unit test) for the HTTP POST/PUT calls and securely store credentials in Security database for use with REST calls.